### PR TITLE
add utf-8 support for logger to avoid UnicodeEncodeError

### DIFF
--- a/FSGenerator.py
+++ b/FSGenerator.py
@@ -81,7 +81,7 @@ class GlobalState:
             self.logger.setLevel(logging.INFO)
 
             # Create a file handler
-            file_handler = logging.FileHandler("FSGenerator.log", mode="w")
+            file_handler = logging.FileHandler("FSGenerator.log", mode="w", encoding='utf-8')
             file_handler.setLevel(logging.INFO)
             file_formatter = logging.Formatter(f"%(levelname)s - %(message)s")
             file_handler.setFormatter(file_formatter)


### PR DESCRIPTION
Found an UnicodeEncodeError during output due to the video path contains Japanese characters 
> /video/VR/七沢みあ/MDVR-192/mdvr192-Part2.mp4 . 

Added utf-8 encoding support to fix the problem. 

> Traceback (most recent call last):
  File "C:\Users\hwoarang\miniconda3\envs\VRFunAIGen\Lib\logging\__init__.py", line 1113, in emit
    stream.write(msg + self.terminator)
UnicodeEncodeError: 'cp950' codec can't encode character '\u6ca2' in position 66: illegal multibyte sequence
Call stack:
  File "C:\Users\hwoarang\miniconda3\envs\VRFunAIGen\Lib\threading.py", line 1002, in _bootstrap
    self._bootstrap_inner()
  File "C:\Users\hwoarang\miniconda3\envs\VRFunAIGen\Lib\threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "C:\Users\hwoarang\miniconda3\envs\VRFunAIGen\Lib\threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\hwoarang\Downloads\VR-Funscript-AI-Generator\FSGenerator.py", line 734, in run_processing
    funscript_handler.generate(global_state)
  File "C:\Users\hwoarang\Downloads\VR-Funscript-AI-Generator\utils\lib_FunscriptHandler.py", line 110, in generate
    global_state.logger.info(f"Funscript generated and saved to {output_path}")