### PR TITLE
Fix funscript version checking against older generated funscripts

### DIFF
--- a/script_generator/funscript/util/check_existing_funscript.py
+++ b/script_generator/funscript/util/check_existing_funscript.py
@@ -27,6 +27,6 @@ def check_existing_funscript(dest_path: str, filename_base: str, make_funscript_
 
     out_of_date = False
     if is_ours:
-        out_of_date = version_is_less_than(json_data.get("version"), FUNSCRIPT_VERSION)
+        out_of_date = version_is_less_than(json_data.get("version", "0.0.1"), FUNSCRIPT_VERSION)
 
     return True, is_ours, backup_path, out_of_date

--- a/script_generator/utils/version.py
+++ b/script_generator/utils/version.py
@@ -1,9 +1,28 @@
+import re
+from script_generator.debug.logger import log_fun
+
+def sanitize_version(version: str) -> str:
+    """
+    Extracts the leading semantic version (digits and dots) from a version string.
+    For example, "0.0.1_25-01-16" becomes "0.0.1".
+    """
+
+    match = re.match(r"(\d+(?:\.\d+)*)", version)
+    return match.group(1) if match else version
+
 def version_is_less_than(version_a: str, version_b: str) -> bool:
     """
     Compare two semantic version strings (e.g., "0.2.1" and "0.10.0")
     and return True if version_a < version_b.
     """
-    parts_a = [int(x) for x in version_a.split('.')]
-    parts_b = [int(x) for x in version_b.split('.')]
+
+    # Sanitize the version strings by extracting the semantic version part.
+    sanitized_a = sanitize_version(version_a)
+    sanitized_b = sanitize_version(version_b)
+
+    log_fun.debug(f"Comparing versions: {sanitized_a} < {sanitized_b}")
+    
+    parts_a = [int(x) for x in sanitized_a.split('.')]
+    parts_b = [int(x) for x in sanitized_b.split('.')]
 
     return parts_a < parts_b


### PR DESCRIPTION
This PR does two things:

1. Older versions of the generator produced funscripts with version strings like "0.0.1_25-01-16" which will crash the current version check, as it needs to be able to convert each element to an integer.  This PR "sanitizes" the read version strings to be simple semantic "x.y.z" so "0.0.1_25-01-16" becomes "0.0.1"
2. For safety, adds a default version of "0.0.1" if for some reason the script doesn't have a version key.