### PR TITLE
Refactor: Centralized Color Management

### DIFF
--- a/application/classes/gauge.py
+++ b/application/classes/gauge.py
@@ -1,6 +1,6 @@
 import imgui
 import numpy as np
-
+from config.element_group_colors import GaugeColors
 
 class GaugeWindow:
     def __init__(self, app_instance, timeline_num: int):
@@ -54,7 +54,6 @@ class GaugeWindow:
         stored_pos_int = (int(window_pos[0]), int(window_pos[1]))
         stored_size_int = (int(window_size[0]), int(window_size[1]))
 
-
         if current_pos_int != stored_pos_int or current_size_int != stored_size_int:
             setattr(app_state, window_pos_attr, current_pos_int)
             setattr(app_state, window_size_attr, current_size_int)
@@ -81,11 +80,11 @@ class GaugeWindow:
             return
 
         # Colors
-        bg_color = imgui.get_color_u32_rgba(0.1, 0.1, 0.1, 1.0)
-        border_color = imgui.get_color_u32_rgba(0.5, 0.5, 0.5, 1.0)
+        bg_color = imgui.get_color_u32_rgba(*GaugeColors.BACKGROUND)
+        border_color = imgui.get_color_u32_rgba(*GaugeColors.BORDER)
         # Change bar color for the second timeline's gauge
-        bar_color_fill = imgui.get_color_u32_rgba(0.7, 0.2, 0.2, 1.0) if self.timeline_num == 2 else imgui.get_color_u32_rgba(0.2, 0.7, 0.2, 1.0)
-        text_color = imgui.get_color_u32_rgba(0.9, 0.9, 0.9, 1.0)
+        bar_color_fill = imgui.get_color_u32_rgba(*GaugeColors.BAR_RED) if self.timeline_num == 2 else imgui.get_color_u32_rgba(*GaugeColors.BAR_GREEN)
+        text_color = imgui.get_color_u32_rgba(*GaugeColors.TEXT)
 
         # Draw gauge background and border
         draw_list.add_rect_filled(gauge_area_x, gauge_area_y,
@@ -125,6 +124,6 @@ class GaugeWindow:
         text_pos_y_val = gauge_area_y + gauge_area_height + (padding / 2 if gauge_area_height > 0 else padding)
 
         imgui.set_cursor_pos((text_pos_x_val - content_start_pos[0], text_pos_y_val - content_start_pos[1]))
-        imgui.text_colored(value_text, 0.9, 0.9, 0.1, 1.0)  # Yellowish text for value
+        imgui.text_colored(value_text, *GaugeColors.VALUE_TEXT)  # Yellowish text for value
 
         imgui.end()

--- a/application/classes/interactive_timeline.py
+++ b/application/classes/interactive_timeline.py
@@ -8,6 +8,7 @@ from typing import Optional, List, Dict, Tuple
 from bisect import bisect_left, bisect_right
 
 from application.utils.time_format import _format_time
+from config.element_group_colors import TimelineColors
 
 
 class InteractiveFunscriptTimeline:
@@ -1222,9 +1223,7 @@ class InteractiveFunscriptTimeline:
                             self._update_preview('ultimate')
                         imgui.same_line(230);
                         imgui.push_item_width(180)
-                        c, self.ultimate_presmoothing_max_window = imgui.slider_int("Max Window##UltimateSmoothWindow",
-                                                                                    self.ultimate_presmoothing_max_window,
-                                                                                    5, 35)
+                        c, self.ultimate_presmoothing_max_window = imgui.slider_int("Max Window##UltimateSmoothWindow", self.ultimate_presmoothing_max_window, 5, 35)
                         if c:
                             if self.ultimate_presmoothing_max_window % 2 == 0:
                                 self.ultimate_presmoothing_max_window += 1
@@ -1238,8 +1237,7 @@ class InteractiveFunscriptTimeline:
                             self._update_preview('ultimate')
                         imgui.same_line(230);
                         imgui.push_item_width(180)
-                        c, self.ultimate_peaks_prominence = imgui.slider_int("Prominence##UltimateProminence",
-                                                                             self.ultimate_peaks_prominence, 1, 50)
+                        c, self.ultimate_peaks_prominence = imgui.slider_int("Prominence##UltimateProminence", self.ultimate_peaks_prominence, 1, 50)
                         if c:
                             self._update_preview('ultimate')
                         imgui.pop_item_width()
@@ -1285,8 +1283,7 @@ class InteractiveFunscriptTimeline:
                             self._update_preview('ultimate')
                         imgui.same_line(230);
                         imgui.push_item_width(180)
-                        c, self.ultimate_speed_threshold = imgui.slider_float("Speed##UltimateSpeedLimit", self.ultimate_speed_threshold, 100.0,
-                                                                              1000.0, "%.0f")
+                        c, self.ultimate_speed_threshold = imgui.slider_float("Speed##UltimateSpeedLimit", self.ultimate_speed_threshold, 100.0, 1000.0, "%.0f")
                         if c:
                             self._update_preview('ultimate')
                         imgui.pop_item_width()
@@ -1429,16 +1426,11 @@ class InteractiveFunscriptTimeline:
                         ):
                             fs_proc._finalize_action_and_update_ui(self.timeline_num, op_desc)
                             # Save settings
-                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_height",
-                                                      self.peaks_height)
-                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_threshold",
-                                                      self.peaks_threshold)
-                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_distance",
-                                                      self.peaks_distance)
-                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_prominence",
-                                                      self.peaks_prominence)
-                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_width",
-                                                      self.peaks_width)
+                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_height", self.peaks_height)
+                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_threshold", self.peaks_threshold)
+                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_distance", self.peaks_distance)
+                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_prominence", self.peaks_prominence)
+                            self.app.app_settings.set(f"timeline{self.timeline_num}_peaks_default_width", self.peaks_width)
                             self.app.logger.info(f"{op_desc} on T{self.timeline_num}.", extra={'status_message': True})
 
                         self.clear_preview()
@@ -1582,7 +1574,7 @@ class InteractiveFunscriptTimeline:
             if not self.show_sg_settings_popup and not self.show_rdp_settings_popup and not self.show_peaks_settings_popup and not self.show_amp_settings_popup and not self.show_keyframe_settings_popup and not self.show_speed_limiter_popup and not self.show_autotune_popup and not self.show_ultimate_autotune_popup:
                 self.clear_preview()
 
-            imgui.text_colored(script_info_text, 0.75, 0.75, 0.75, 0.95)
+            imgui.text_colored(script_info_text, 0.75, 0.75, 0.75, 0.95) # TODO: change to theme color
             # --- (Drag and drop target for T2 remains the same) ---
             if self.timeline_num == 2:
                 if imgui.begin_drag_drop_target():
@@ -1605,7 +1597,7 @@ class InteractiveFunscriptTimeline:
                 imgui.end()
                 return
 
-            draw_list.add_rect_filled(canvas_abs_pos[0], canvas_abs_pos[1], canvas_abs_pos[0] + canvas_size[0], canvas_abs_pos[1] + canvas_size[1], imgui.get_color_u32_rgba(0.08, 0.08, 0.1, 1))
+            draw_list.add_rect_filled(canvas_abs_pos[0], canvas_abs_pos[1], canvas_abs_pos[0] + canvas_size[0], canvas_abs_pos[1] + canvas_size[1], imgui.get_color_u32_rgba(*TimelineColors.CANVAS_BACKGROUND))
 
             video_loaded = self.app.processor and self.app.processor.video_info and self.app.processor.total_frames > 0
 
@@ -1650,9 +1642,7 @@ class InteractiveFunscriptTimeline:
                 # if can_manual_pan_zoom:
                 time_at_current_center_ms = x_to_time(center_x_marker)
                 scale_factor = self.zoom_action_request
-                app_state.timeline_zoom_factor_ms_per_px = max(0.01,
-                                                               min(app_state.timeline_zoom_factor_ms_per_px * scale_factor,
-                                                                   2000.0))
+                app_state.timeline_zoom_factor_ms_per_px = max(0.01, min(app_state.timeline_zoom_factor_ms_per_px * scale_factor, 2000.0))
                 app_state.timeline_pan_offset_ms = time_at_current_center_ms - (
                             canvas_size[0] / 2.0) * app_state.timeline_zoom_factor_ms_per_px
                 app_state.timeline_interaction_active = True
@@ -1832,8 +1822,7 @@ class InteractiveFunscriptTimeline:
 
                     actions_list.sort(key=lambda a: a["at"])
                     # Re-select moved points robustly
-                    self.multi_selected_action_indices = {actions_list.index(obj) for obj in objects_to_move if
-                                                          obj in actions_list}
+                    self.multi_selected_action_indices = {actions_list.index(obj) for obj in objects_to_move if obj in actions_list}
                     self.selected_action_idx = min(
                         self.multi_selected_action_indices) if self.multi_selected_action_indices else -1
                     fs_proc._finalize_action_and_update_ui(self.timeline_num, op_desc)
@@ -1903,8 +1892,7 @@ class InteractiveFunscriptTimeline:
                         )
 
                         # Re-fetch actions and select the new point
-                        actions_list = getattr(target_funscript_instance_for_render, f"{axis_name_for_render}_actions",
-                                               [])
+                        actions_list = getattr(target_funscript_instance_for_render, f"{axis_name_for_render}_actions", [])
                         new_idx = next((idx for idx, act in enumerate(actions_list) if
                                         act['at'] == snapped_time_add_key and act['pos'] == target_pos_val), -1)
                         if new_idx != -1:
@@ -1956,7 +1944,7 @@ class InteractiveFunscriptTimeline:
                 if pan_to_current_frame:
                     app_state.force_timeline_pan_to_current_frame = False
 
-            marker_color_fixed = imgui.get_color_u32_rgba(0.9, 0.2, 0.2, 0.9)
+            marker_color_fixed = imgui.get_color_u32_rgba(*TimelineColors.CENTER_MARKER)
             draw_list.add_line(center_x_marker, canvas_abs_pos[1], center_x_marker, canvas_abs_pos[1] + canvas_size[1], marker_color_fixed, 1.5)
             tri_half_base, tri_height = 5.0, 8.0
 
@@ -1977,18 +1965,18 @@ class InteractiveFunscriptTimeline:
 
             full_time_display_str = f"{time_str_display_main}{frame_str_display}"
             draw_list.add_text(center_x_marker + 5, canvas_abs_pos[1] + tri_height + 5,
-                               imgui.get_color_u32_rgba(1, 1, 1, 0.7), full_time_display_str)
+                               imgui.get_color_u32_rgba(*TimelineColors.TIME_DISPLAY_TEXT), full_time_display_str)
 
             # Grid drawing (Horizontal - Position)
             for i in range(5):  # 0, 25, 50, 75, 100
                 y_grid_h = canvas_abs_pos[1] + (i / 4.0) * canvas_size[1]
-                grid_col = imgui.get_color_u32_rgba(0.2, 0.2, 0.2, 0.8 if i != 2 else 0.9)  # Center line darker
+                grid_col = imgui.get_color_u32_rgba(*TimelineColors.GRID_LINES if i != 2 else TimelineColors.GRID_MAJOR_LINES)  # Center line darker
                 line_thickness = 1.0 if i != 2 else 1.5
                 draw_list.add_line(canvas_abs_pos[0], y_grid_h, canvas_abs_pos[0] + canvas_size[0], y_grid_h, grid_col, line_thickness)
                 pos_val = 100 - int((i / 4.0) * 100)
                 text_y_offset = -imgui.get_text_line_height() - 2 if i == 4 else (
                     2 if i == 0 else -imgui.get_text_line_height() / 2)
-                draw_list.add_text(canvas_abs_pos[0] + 3, y_grid_h + text_y_offset, imgui.get_color_u32_rgba(0.7, 0.7, 0.7, 1), str(pos_val))
+                draw_list.add_text(canvas_abs_pos[0] + 3, y_grid_h + text_y_offset, imgui.get_color_u32_rgba(*TimelineColors.GRID_LABELS), str(pos_val))
 
             # Grid drawing (Vertical - Time)
             time_per_screen_ms_grid = canvas_size[0] * app_state.timeline_zoom_factor_ms_per_px
@@ -2025,7 +2013,7 @@ class InteractiveFunscriptTimeline:
                         continue
 
                     is_major_tick = (t_ms % (time_step_ms_grid * 5)) == 0
-                    tick_color = imgui.get_color_u32_rgba(0.2, 0.2, 0.2, 0.9 if is_major_tick else 0.8)
+                    tick_color = imgui.get_color_u32_rgba(*TimelineColors.GRID_MAJOR_LINES if is_major_tick else TimelineColors.GRID_LINES)
                     tick_thickness = 1.5 if is_major_tick else 1.0
 
                     # Draw vertical grid line
@@ -2037,7 +2025,7 @@ class InteractiveFunscriptTimeline:
                     # Optionally draw time label
                     if not video_loaded or (0 <= t_ms <= effective_total_duration_ms + 1e-4):
                         label = f"{t_ms / 1000.0:.1f}s"
-                        label_color = imgui.get_color_u32_rgba(0.7, 0.7, 0.7, 1.0)
+                        label_color = imgui.get_color_u32_rgba(*TimelineColors.GRID_LABELS)
                         draw_list.add_text(x_pos + 3, canvas_abs_pos[1] + 3, label_color, label)
 
             # --- Draw Audio Waveform ---
@@ -2067,7 +2055,7 @@ class InteractiveFunscriptTimeline:
                             y_coords_top = canvas_center_y - y_offsets
                             y_coords_bottom = canvas_center_y + y_offsets
 
-                        waveform_color = imgui.get_color_u32_rgba(0.2, 0.35, 0.6, 0.6)
+                        waveform_color = imgui.get_color_u32_rgba(*TimelineColors.AUDIO_WAVEFORM)
                         points_top = list(zip(x_coords, y_coords_top))
                         points_bottom = list(zip(x_coords, y_coords_bottom))
                         draw_list.add_polyline(points_top, waveform_color, False, 1.0)
@@ -2172,16 +2160,16 @@ class InteractiveFunscriptTimeline:
                         is_in_multi_selection = (original_list_idx in self.multi_selected_action_indices)
                         is_being_dragged = (original_list_idx == self.dragging_action_idx)
                         point_radius_draw = app_state.timeline_point_radius
-                        pt_color_tuple = (0.3, 0.9, 0.3, 1)
+                        pt_color_tuple = TimelineColors.POINT_DEFAULT
 
                         if is_being_dragged:
-                            pt_color_tuple = (1.0, 0.2, 0.2, 1.0)
+                            pt_color_tuple = TimelineColors.POINT_DRAGGING
                             point_radius_draw += 1
                         elif is_primary_selected or is_in_multi_selection:
-                            pt_color_tuple = (1.0, 0.0, 0.0, 1.0)
+                            pt_color_tuple = TimelineColors.POINT_SELECTED
                             if is_in_multi_selection and not is_primary_selected: point_radius_draw += 0.5
                         elif is_hovered_pt and imgui.is_window_hovered() and not self.is_marqueeing:
-                            pt_color_tuple = (0.5, 1.0, 0.5, 1.0)
+                            pt_color_tuple = TimelineColors.POINT_HOVER
                             if self.dragging_action_idx == -1:
                                 hovered_action_idx_current_timeline = original_list_idx
 
@@ -2191,12 +2179,12 @@ class InteractiveFunscriptTimeline:
                         draw_list.add_circle_filled(px, py, point_radius_draw, final_pt_color)
 
                         if is_primary_selected and not is_being_dragged:
-                            draw_list.add_circle(px, py, point_radius_draw + 1, imgui.get_color_u32_rgba(0.6, 0.0, 0.0, 1.0), thickness=1.0)
+                            draw_list.add_circle(px, py, point_radius_draw + 1, imgui.get_color_u32_rgba(*TimelineColors.SELECTED_POINT_BORDER), thickness=1.0)
 
             # --- Draw Preview Actions on Top ---
             if self.is_previewing and self.preview_actions:
-                preview_line_color = imgui.get_color_u32_rgba(1.0, 0.5, 0.0, 0.9)  # Bright Orange
-                preview_point_color = imgui.get_color_u32_rgba(1.0, 0.5, 0.0, 1.0)
+                preview_line_color = imgui.get_color_u32_rgba(*TimelineColors.PREVIEW_LINES)  # Bright Orange
+                preview_point_color = imgui.get_color_u32_rgba(*TimelineColors.PREVIEW_POINTS)
                 preview_point_radius = app_state.timeline_point_radius
 
                 # Draw preview lines and points using the self.preview_actions list
@@ -2218,8 +2206,8 @@ class InteractiveFunscriptTimeline:
             if self.is_marqueeing and self.marquee_start_screen_pos and self.marquee_end_screen_pos:
                 min_x, max_x = min(self.marquee_start_screen_pos[0], self.marquee_end_screen_pos[0]), max(self.marquee_start_screen_pos[0], self.marquee_end_screen_pos[0])
                 min_y, max_y = min(self.marquee_start_screen_pos[1], self.marquee_end_screen_pos[1]), max(self.marquee_start_screen_pos[1], self.marquee_end_screen_pos[1])
-                draw_list.add_rect_filled(min_x, min_y, max_x, max_y, imgui.get_color_u32_rgba(0.5, 0.5, 1.0, 0.3))
-                draw_list.add_rect(min_x, min_y, max_x, max_y, imgui.get_color_u32_rgba(0.8, 0.8, 1.0, 0.7))
+                draw_list.add_rect_filled(min_x, min_y, max_x, max_y, imgui.get_color_u32_rgba(*TimelineColors.MARQUEE_SELECTION_FILL))
+                draw_list.add_rect(min_x, min_y, max_x, max_y, imgui.get_color_u32_rgba(*TimelineColors.MARQUEE_SELECTION_BORDER))
 
             # --- Mouse Interactions ---
             # region Mouse

--- a/application/classes/lr_dial.py
+++ b/application/classes/lr_dial.py
@@ -1,5 +1,6 @@
 import imgui
 import numpy as np
+from config.element_group_colors import LRDialColors
 
 
 class LRDialWindow:
@@ -14,11 +15,9 @@ class LRDialWindow:
             return
 
         # One-time Y position adjustment after main menu bar height is known
-        if not self.lr_dial_pos_initialized and hasattr(app_state,
-                                                        'main_menu_bar_height') and app_state.main_menu_bar_height > 0:
+        if not self.lr_dial_pos_initialized and hasattr(app_state, 'main_menu_bar_height') and app_state.main_menu_bar_height > 0:
 
-            default_uninitialized_y_placeholder = self.app.app_settings.get("lr_dial_window_pos_y",
-                                                                            35)  # Get what default Y might have been
+            default_uninitialized_y_placeholder = self.app.app_settings.get("lr_dial_window_pos_y", 35)  # Get what default Y might have been
 
             if app_state.lr_dial_window_pos[1] == default_uninitialized_y_placeholder or \
                     app_state.lr_dial_window_pos[1] < app_state.main_menu_bar_height:
@@ -90,17 +89,14 @@ class LRDialWindow:
 
         # Draw dial background and border
         draw_list.add_circle_filled(center_x_dial, center_y_dial, radius,
-                                    imgui.get_color_u32_rgba(0.2, 0.2, 0.2, 1), num_segments=32)
-        draw_list.add_circle(center_x_dial, center_y_dial, radius, imgui.get_color_u32_rgba(0.5, 0.5, 0.5, 1),
-                             num_segments=32, thickness=1)
+                                    imgui.get_color_u32_rgba(*LRDialColors.BACKGROUND), num_segments=32)
+        draw_list.add_circle(center_x_dial, center_y_dial, radius, imgui.get_color_u32_rgba(*LRDialColors.BORDER), num_segments=32, thickness=1)
 
         # Draw L and R labels
         l_text_size = imgui.calc_text_size("L")
         r_text_size = imgui.calc_text_size("R")
-        draw_list.add_text(center_x_dial - radius - l_text_size[0] - 5, center_y_dial - l_text_size[1] / 2,
-                           imgui.get_color_u32_rgba(0.8, 0.2, 0.2, 1), "L")  # Red for Left
-        draw_list.add_text(center_x_dial + radius + 5, center_y_dial - r_text_size[1] / 2,
-                           imgui.get_color_u32_rgba(0.2, 0.2, 0.8, 1), "R")  # Blue for Right
+        draw_list.add_text(center_x_dial - radius - l_text_size[0] - 5, center_y_dial - l_text_size[1] / 2, imgui.get_color_u32_rgba(*LRDialColors.LEFT_LABEL), "L")  # Red for Left
+        draw_list.add_text(center_x_dial + radius + 5, center_y_dial - r_text_size[1] / 2, imgui.get_color_u32_rgba(*LRDialColors.RIGHT_LABEL), "R")  # Blue for Right
 
         # Get dial value from app_state
         current_dial_value = int(app_state.lr_dial_value)  # Value 0-100
@@ -117,10 +113,8 @@ class LRDialWindow:
         indicator_tip_y = center_y_dial + indicator_len * np.sin(angle_rad_for_drawing)
 
         # Draw indicator line and tip
-        draw_list.add_line(center_x_dial, center_y_dial, indicator_tip_x, indicator_tip_y,
-                           imgui.get_color_u32_rgba(0.1, 0.8, 0.8, 1), thickness=3)
-        draw_list.add_circle_filled(indicator_tip_x, indicator_tip_y, 4,
-                                    imgui.get_color_u32_rgba(0.9, 0.9, 0.1, 1))  # Yellow tip
+        draw_list.add_line(center_x_dial, center_y_dial, indicator_tip_x, indicator_tip_y, imgui.get_color_u32_rgba(*LRDialColors.INDICATOR_LINE), thickness=3)
+        draw_list.add_circle_filled(indicator_tip_x, indicator_tip_y, 4, imgui.get_color_u32_rgba(*LRDialColors.INDICATOR_TIP))  # Yellow tip
 
         # Display the numerical value below the dial
         l_r_value_text = f"{current_dial_value:02d}"  # e.g., "05", "50", "95"
@@ -131,6 +125,6 @@ class LRDialWindow:
         text_pos_y = canvas_origin_y + drawable_height + 5  # Below the dial drawing area
 
         imgui.set_cursor_screen_pos((text_pos_x, text_pos_y))
-        imgui.text_colored(l_r_value_text, 0.9, 0.9, 0.8, 1.0)  # Light text for value
+        imgui.text_colored(l_r_value_text, *LRDialColors.VALUE_TEXT)  # Light text for value
 
         imgui.end()

--- a/application/classes/menu.py
+++ b/application/classes/menu.py
@@ -90,7 +90,7 @@ class MainMenu:
 
                 imgui.text_wrapped(
                     f"The Target (T{target_timeline_num}) appears to be delayed relative to the Reference (T{ref_timeline_num}) by:")
-                imgui.push_style_color(imgui.COLOR_TEXT, 1.0, 1.0, 0.0, 1.0)
+                imgui.push_style_color(imgui.COLOR_TEXT, 1.0, 1.0, 0.0, 1.0) # TODO: move to theme, yellow
                 imgui.text(f"  {offset_ms} milliseconds{frame_offset_str}")
                 imgui.pop_style_color()
 
@@ -537,7 +537,7 @@ class MainMenu:
                                  imgui.get_style().item_spacing[0] * 2
                 if padding_needed > 0:
                     imgui.same_line(cursor_x_after_menus + padding_needed)
-                imgui.text_colored(app_state.status_message, 0.9, 0.9, 0.3, 1.0)
+                imgui.text_colored(app_state.status_message, 0.9, 0.9, 0.3, 1.0) # TODO: move to theme, yellow
             elif app_state.status_message:
                 app_state.status_message = ""
 

--- a/application/gui_components/app_gui.py
+++ b/application/gui_components/app_gui.py
@@ -22,6 +22,7 @@ from application.gui_components.generated_file_manager_window import GeneratedFi
 from application.gui_components.autotuner_window import AutotunerWindow
 
 from config import constants
+from config.element_group_colors import AppGUIColors
 
 
 class GUI:
@@ -367,7 +368,7 @@ class GUI:
                             imgui.WINDOW_NO_NAV)
 
             imgui.begin("EnergySaverIndicator", closable=False, flags=window_flags)
-            imgui.text_colored(indicator_text, 0.4, 0.9, 0.4, 1.0)  # Greenish text
+            imgui.text_colored(indicator_text, 0.4, 0.9, 0.4, 1.0)  # TODO: move to theme, green
             imgui.end()
 
     # --- This function now submits a task to the worker thread ---
@@ -431,7 +432,7 @@ class GUI:
             if total_frames > 0:
                 normalized_pos = self.app.processor.current_frame_index / (total_frames - 1.0)
                 marker_x = (canvas_p1_x + style.frame_padding[0]) + (normalized_pos * (current_bar_width_float - style.frame_padding[0] * 2))
-                marker_color = imgui.get_color_u32_rgba(0.9, 0.2, 0.2, 0.85)
+                marker_color = imgui.get_color_u32_rgba(*AppGUIColors.MARKER)
                 draw_list_marker = imgui.get_window_draw_list()
                 draw_list_marker.add_line(marker_x, canvas_p1_y_offset, marker_x, canvas_p1_y_offset + graph_height, marker_color, 1.0)
 
@@ -528,7 +529,7 @@ class GUI:
         app_state = self.app.app_state_ui
         if not imgui.is_item_visible():
             return
-        marks = [(current_target_fps, (255, 255, 0), "Target"), (tracker_fps, (0, 255, 0), "Tracker"), (processor_fps, (255, 0, 0), "Processor")]
+        marks = [(current_target_fps, AppGUIColors.FPS_TARGET_MARKER, "Target"), (tracker_fps, AppGUIColors.FPS_TRACKER_MARKER, "Tracker"), (processor_fps, AppGUIColors.FPS_PROCESSOR_MARKER, "Processor")]
         slider_x_start, slider_x_end = min_rect.x, max_rect.x
         slider_width = slider_x_end - slider_x_start
         slider_y = (min_rect.y + max_rect.y) / 2
@@ -987,7 +988,7 @@ class GUI:
                 frame_start_time = time.time()
                 glfw.poll_events()
                 if self.impl: self.impl.process_inputs()
-                gl.glClearColor(0.06, 0.06, 0.06, 1)
+                gl.glClearColor(0.06, 0.06, 0.06, 1) # TODO: move to theme, dark gray
                 gl.glClear(gl.GL_COLOR_BUFFER_BIT)
                 self.render_gui()
                 if self.app.app_settings.get("autosave_enabled", True) and time.time() - self.app.project_manager.last_autosave_time > self.app.app_settings.get("autosave_interval_seconds", 300):

--- a/application/gui_components/autotuner_window.py
+++ b/application/gui_components/autotuner_window.py
@@ -28,7 +28,7 @@ class AutotunerWindow:
                 is_running = self.app.is_autotuning_active
 
                 if not is_ready:
-                    imgui.text_colored("Please load a video first.", 1.0, 0.5, 0.5, 1.0)
+                    imgui.text_colored("Please load a video first.", 1.0, 0.5, 0.5, 1.0) # TODO: move to theme, red
 
                 # --- UI for selecting test mode ---
                 hwaccel_options = ["Default (Test CPU + Best GPU)"] + self.app.available_ffmpeg_hwaccels
@@ -67,7 +67,7 @@ class AutotunerWindow:
                 # --- Status & Progress ---
                 imgui.text("Status:")
                 imgui.same_line()
-                imgui.text_colored(self.app.autotuner_status_message, 0.2, 0.8, 1.0, 1.0)
+                imgui.text_colored(self.app.autotuner_status_message, 0.2, 0.8, 1.0, 1.0) # TODO: move to theme, blue
 
                 if is_running:
                     stage_proc = self.app.stage_processor
@@ -97,7 +97,7 @@ class AutotunerWindow:
                         # If this is the best row, push a new text color
                         if is_best:
                             # Push a bright green color for the text
-                            imgui.push_style_color(imgui.COLOR_TEXT, 0.4, 1.0, 0.4, 1.0)
+                            imgui.push_style_color(imgui.COLOR_TEXT, 0.4, 1.0, 0.4, 1.0) # TODO: move to theme, green
 
                         imgui.table_set_column_index(0)
                         imgui.text(accel)

--- a/application/gui_components/control_panel_ui.py
+++ b/application/gui_components/control_panel_ui.py
@@ -3,6 +3,7 @@ import os
 from config import constants
 from config.constants import TrackerMode, SCENE_DETECTION_DEFAULT_THRESHOLD, AI_MODEL_EXTENSIONS_FILTER, AI_MODEL_TOOLTIP_EXTENSIONS
 import time
+from config.element_group_colors import ControlPanelColors, GeneralColors
 
 class ControlPanelUI:
     def __init__(self, app):
@@ -697,7 +698,7 @@ class ControlPanelUI:
                 display_key = "PRESS KEY..."
                 button_text = "Cancel"
 
-            imgui.text_colored(display_key, 0.2, 0.8, 1.0, 1.0)
+            imgui.text_colored(display_key, 0.2, 0.8, 1.0, 1.0) # TODO: move to theme, blue
             imgui.same_line()
 
             if imgui.button(f"{button_text}##record_btn_{action_name}"):
@@ -908,7 +909,7 @@ class ControlPanelUI:
         is_any_process_active = is_batch_mode or is_analysis_running or is_live_tracking_running or is_setting_roi or stage_proc.scene_detection_active
 
         if is_batch_mode:
-            imgui.text_ansi_colored("--- BATCH PROCESSING ACTIVE ---", 1.0, 0.7, 0.3)
+            imgui.text_ansi_colored("--- BATCH PROCESSING ACTIVE ---", 1.0, 0.7, 0.3) # TODO: move to theme, orange
             total_videos = len(self.app.batch_video_paths)
             current_idx = self.app.current_batch_video_index
             if 0 <= current_idx < total_videos:
@@ -964,8 +965,8 @@ class ControlPanelUI:
         is_analysis_running = stage_proc.full_analysis_active
         selected_mode = self.app.app_state_ui.selected_tracker_mode
 
-        active_progress_color = (0.2, 0.6, 1.0, 1.0) # Vibrant blue for active
-        completed_progress_color = (0.2, 0.7, 0.2, 1.0) # Vibrant green for completed
+        active_progress_color = ControlPanelColors.ACTIVE_PROGRESS # Vibrant blue for active
+        completed_progress_color = ControlPanelColors.COMPLETED_PROGRESS # Vibrant green for completed
 
         # Stage 1
         imgui.text("Stage 1: YOLO Object Detection")
@@ -981,13 +982,13 @@ class ControlPanelUI:
             frame_q_size = stage_proc.stage1_frame_queue_size
             frame_q_max = constants.STAGE1_FRAME_QUEUE_MAXSIZE
             frame_q_fraction = frame_q_size / frame_q_max if frame_q_max > 0 else 0.0
-            suggestion_message, bar_color = "", (0.2, 0.8, 0.2)
+            suggestion_message, bar_color = "", (0.2, 0.8, 0.2) # TODO: move to theme, green
             if frame_q_fraction > 0.9:
-                bar_color, suggestion_message = (0.9, 0.3, 0.3), "Suggestion: Add consumer if resources allow"
+                bar_color, suggestion_message = (0.9, 0.3, 0.3), "Suggestion: Add consumer if resources allow" # TODO: move to theme, red
             elif frame_q_fraction > 0.2:
-                bar_color, suggestion_message = (1.0, 0.5, 0.0), "Balanced"
+                bar_color, suggestion_message = (1.0, 0.5, 0.0), "Balanced" # TODO: move to theme, yellow
             else:
-                bar_color, suggestion_message = (0.2, 0.8, 0.2), "Suggestion: Lessen consumers or add producer"
+                bar_color, suggestion_message = (0.2, 0.8, 0.2), "Suggestion: Lessen consumers or add producer" # TODO: move to theme, green
             imgui.push_style_color(imgui.COLOR_PLOT_HISTOGRAM, *bar_color)
             imgui.progress_bar(frame_q_fraction, size=(-1, 0), overlay=f"Frame Queue: {frame_q_size}/{frame_q_max}")
             imgui.pop_style_color()
@@ -1038,7 +1039,7 @@ class ControlPanelUI:
                 if stage_proc.stage2_sub_time_elapsed_str:
                     imgui.text(f"Time: {stage_proc.stage2_sub_time_elapsed_str} | ETA: {stage_proc.stage2_sub_eta_str} | Speed: {stage_proc.stage2_sub_processing_fps_str}")
 
-                sub_progress_color = (0.3, 0.7, 1.0, 1.0)
+                sub_progress_color = ControlPanelColors.SUB_PROGRESS
                 imgui.push_style_color(imgui.COLOR_PLOT_HISTOGRAM, *sub_progress_color)
 
                 # Construct the overlay text with a percentage.
@@ -1216,7 +1217,7 @@ class ControlPanelUI:
             imgui.internal.pop_item_flag()
 
         if self.app.is_setting_user_roi_mode:
-            imgui.text_ansi_colored("Selection Active: Draw ROI then click point on video.", 1.0, 0.7, 0.2)
+            imgui.text_ansi_colored("Selection Active: Draw ROI then click point on video.", 1.0, 0.7, 0.2) # TODO: move to theme, orange
 
     def _render_interactive_refinement_controls(self):
         """Renders the interactive refinement toggle and status, visible only when relevant."""
@@ -1234,9 +1235,9 @@ class ControlPanelUI:
             imgui.push_style_var(imgui.STYLE_ALPHA, imgui.get_style().alpha * 0.5)
 
         if is_enabled:
-            imgui.push_style_color(imgui.COLOR_BUTTON, 0.8, 0.2, 0.2, 1.0)
-            imgui.push_style_color(imgui.COLOR_BUTTON_HOVERED, 0.9, 0.3, 0.3, 1.0)
-            imgui.push_style_color(imgui.COLOR_BUTTON_ACTIVE, 1.0, 0.2, 0.2, 1.0)
+            imgui.push_style_color(imgui.COLOR_BUTTON, GeneralColors.RED_DARK)
+            imgui.push_style_color(imgui.COLOR_BUTTON_HOVERED, GeneralColors.RED_LIGHT)
+            imgui.push_style_color(imgui.COLOR_BUTTON_ACTIVE, GeneralColors.RED)
             button_text = "Disable Refinement Mode"
         else:
             button_text = "Enable Refinement Mode"
@@ -1253,9 +1254,9 @@ class ControlPanelUI:
 
         if is_enabled:
             if self.app.stage_processor.refinement_analysis_active:
-                imgui.text_ansi_colored("Refining chapter...", 1.0, 0.7, 0.2)
+                imgui.text_ansi_colored("Refining chapter...", 1.0, 0.7, 0.2) # TODO: move to theme, orange
             else:
-                imgui.text_ansi_colored("Click a box in the video to start.", 0.2, 1.0, 0.2)
+                imgui.text_ansi_colored("Click a box in the video to start.", 0.2, 1.0, 0.2) # TODO: move to theme, green
 
         if refinement_disabled:
             if imgui.is_item_hovered():
@@ -1509,7 +1510,7 @@ class ControlPanelUI:
             imgui.internal.pop_item_flag()
 
     def _render_latency_calibration(self, calibration_mgr):
-        imgui.text_ansi_colored("--- LATENCY CALIBRATION MODE ---", 1.0, 0.7, 0.3)
+        imgui.text_ansi_colored("--- LATENCY CALIBRATION MODE ---", 1.0, 0.7, 0.3) # TODO: move to theme, orange
         if not calibration_mgr.calibration_reference_point_selected:
             imgui.text_wrapped("1. Start the live tracker for 10s of action then pause it.")
             imgui.text_wrapped("   Select a clear action point on Timeline 1.")

--- a/application/gui_components/engine_compiler/tensorrt_compiler_window.py
+++ b/application/gui_components/engine_compiler/tensorrt_compiler_window.py
@@ -5,14 +5,7 @@ import time
 from application.gui_components.engine_compiler.tensorrt_validation_panel import ValidationPanel
 from application.logic.tensorrt_compiler_logic import TensorRTCompilerLogic
 from config.constants import TENSORRT_OUTPUT_DISPLAY_HEIGHT
-
-# Color palette for compiler window
-_GREEN = (0.2, 0.8, 0.2, 1.0)    # Success color
-_RED = (0.9, 0.2, 0.2, 1.0)      # Error color
-_ORANGE = (1.0, 0.6, 0.0, 1.0)   # In-progress color
-_YELLOW = (0.9, 0.9, 0.2, 1.0)   # Warning color
-_LIGHT_BLUE = (0.7, 0.9, 1.0, 1.0)  # Standard output color
-_GRAY = (0.7, 0.7, 0.7, 1.0)     # Waiting/neutral color
+from config.element_group_colors import CompilerToolColors
 
 class TensorRTCompilerWindow:
     """Main TensorRT compiler window - GUI only."""
@@ -98,8 +91,6 @@ class TensorRTCompilerWindow:
 
     def _render_compilation_controls(self):
         """Render compilation controls."""
-        imgui.separator()
-        
         # Get compilation state from logic
         can_compile = self.logic.can_compile()
         is_compiling = self.logic.get_compilation_status()
@@ -114,12 +105,12 @@ class TensorRTCompilerWindow:
             if not button_enabled:
                 imgui.internal.push_item_flag(imgui.internal.ITEM_DISABLED, True)
                 imgui.push_style_var(imgui.STYLE_ALPHA, imgui.get_style().alpha * 0.5)
-            
+
             if imgui.button("Stop Compilation", width=120):
                 if button_enabled:
                     self.logic.request_stop_compilation()
                     self.last_button_time = current_time
-            
+
             if not button_enabled:
                 imgui.pop_style_var()
                 imgui.internal.pop_item_flag()
@@ -156,21 +147,18 @@ class TensorRTCompilerWindow:
     def _render_colored_status_message(self, message: str):
         """Render status message with appropriate colors."""
         if "Error" in message or "Failed" in message:
-            imgui.text_colored(message, *_RED)
+            imgui.text_colored(message, *CompilerToolColors.ERROR)
         elif "Success" in message or "complete" in message.lower():
-            imgui.text_colored(message, *_GREEN)
+            imgui.text_colored(message, *CompilerToolColors.SUCCESS)
         elif "Starting" in message or "Loading" in message or "Exporting" in message:
-            imgui.text_colored(message, *_ORANGE)
+            imgui.text_colored(message, *CompilerToolColors.STARTING)
         elif "Stopping" in message:
-            imgui.text_colored(message, *_YELLOW)
+            imgui.text_colored(message, *CompilerToolColors.STOPPING)
         else:
-            # Default white for other messages
             imgui.text_wrapped(message)
     
     def _render_subprocess_output(self):
         """Render subprocess output display."""
-        imgui.separator()
-        imgui.text("Compilation Output:")
         
         # Get subprocess output from the compiler
         output_lines = self.logic.compiler.get_subprocess_output()
@@ -179,13 +167,13 @@ class TensorRTCompilerWindow:
         imgui.begin_child("SubprocessOutput", 0, TENSORRT_OUTPUT_DISPLAY_HEIGHT, border=True)
         
         if not output_lines:
-            imgui.text_colored("Waiting for compilation output...", *_GRAY)
+            imgui.text_colored("Waiting for compilation output...", *CompilerToolColors.INFO)
         else:
             for line in output_lines:
                 if line.startswith("[ERR]"):
-                    imgui.text_colored(line, *_RED)
+                    imgui.text_colored(line, *CompilerToolColors.ERROR)
                 elif line.startswith("[OUT]"):
-                    imgui.text_colored(line, *_LIGHT_BLUE)
+                    imgui.text_colored(line, *CompilerToolColors.OUTPUT_TEXT)
                 else:
                     # Default for other lines
                     imgui.text(line)

--- a/application/gui_components/generated_file_manager_window.py
+++ b/application/gui_components/generated_file_manager_window.py
@@ -145,7 +145,7 @@ class GeneratedFileManagerWindow:
         imgui.text_disabled(f"{file_info['size_mb']:.3f} MB")
         imgui.same_line(imgui.get_window_width() - 80)
         imgui.push_id(file_info['path'])
-        imgui.push_style_color(imgui.COLOR_BUTTON, 0.65, 0.15, 0.15)
+        imgui.push_style_color(imgui.COLOR_BUTTON, 0.65, 0.15, 0.15) # TODO: move to theme, red
         is_funscript = file_info['name'].endswith('.funscript')
         delete_enabled = self.file_manager.delete_funscript_files or not is_funscript
         if not delete_enabled:
@@ -163,7 +163,7 @@ class GeneratedFileManagerWindow:
         """Renders the modal popup for confirming deletion of all generated files."""
         opened, visible = imgui.begin_popup_modal("ConfirmDeleteAll")
         if opened:
-            imgui.text_ansi_colored("WARNING: This will delete ALL subfolders and files in the output directory!", 1.0, 0.2, 0.2)
+            imgui.text_ansi_colored("WARNING: This will delete ALL subfolders and files in the output directory!", 1.0, 0.2, 0.2) # TODO: move to theme, red
             imgui.text(f"Directory: {os.path.abspath(self.output_folder)}")
             imgui.text("Contents will be moved to the recycle bin.")
             imgui.separator()

--- a/application/gui_components/video_display_ui.py
+++ b/application/gui_components/video_display_ui.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 
 
 import config.constants as constants
+from config.element_group_colors import VideoDisplayColors
 
 
 class VideoDisplayUI:
@@ -244,12 +245,12 @@ class VideoDisplayUI:
 
         # --- Color based on whether this is the dominant pose ---
         if is_dominant:
-            limb_color = imgui.get_color_u32_rgba(0.1, 1.0, 0.1, 0.95)  # Bright Green
-            kpt_color = imgui.get_color_u32_rgba(1.0, 0.5, 0.1, 1.0)  # Bright Orange
+            limb_color = imgui.get_color_u32_rgba(*VideoDisplayColors.DOMINANT_LIMB)  # Bright Green
+            kpt_color = imgui.get_color_u32_rgba(*VideoDisplayColors.DOMINANT_KEYPOINT)  # Bright Orange
             thickness = 2
         else:
-            limb_color = imgui.get_color_u32_rgba(0.2, 0.6, 1, 0.4)  # Muted Cyan
-            kpt_color = imgui.get_color_u32_rgba(0.9, 0.2, 0.2, 0.5)  # Muted Red
+            limb_color = imgui.get_color_u32_rgba(*VideoDisplayColors.MUTED_LIMB)  # Muted Cyan
+            kpt_color = imgui.get_color_u32_rgba(*VideoDisplayColors.MUTED_KEYPOINT)  # Muted Red
             thickness = 1
 
         skeleton = [[0, 1], [0, 2], [1, 3], [2, 4], [5, 6], [5, 11], [6, 12], [11, 12], [5, 7], [7, 9], [6, 8], [8, 10], [11, 13], [13, 15], [12, 14], [14, 16]]
@@ -275,14 +276,14 @@ class VideoDisplayUI:
         if not motion_mode or motion_mode == 'undetermined':
             return
 
-        mode_color = imgui.get_color_u32_rgba(1, 1, 0, 0.9)
+        mode_color = imgui.get_color_u32_rgba(*VideoDisplayColors.MOTION_UNDETERMINED)
         mode_text = "Undetermined"
 
         if motion_mode == 'thrusting':
             mode_text = "Thrusting"
-            mode_color = imgui.get_color_u32_rgba(0.1, 1.0, 0.1, 0.95)
+            mode_color = imgui.get_color_u32_rgba(*VideoDisplayColors.MOTION_THRUSTING)
         elif motion_mode == 'riding':
-            mode_color = imgui.get_color_u32_rgba(1.0, 0.4, 1.0, 0.95)
+            mode_color = imgui.get_color_u32_rgba(*VideoDisplayColors.MOTION_RIDING)
             if interaction_class == 'face':
                 mode_text = "Blowing"
             elif interaction_class == 'hand':
@@ -406,7 +407,7 @@ class VideoDisplayUI:
                                                 self.user_roi_draw_current_screen_pos[0]),
                                             max(self.user_roi_draw_start_screen_pos[1],
                                                 self.user_roi_draw_current_screen_pos[1]),
-                                            imgui.get_color_u32_rgba(1, 1, 0, 0.7), thickness=2
+                                            imgui.get_color_u32_rgba(*VideoDisplayColors.ROI_DRAWING), thickness=2
                                         )
 
                                     if not io.mouse_down[0] and self.is_drawing_user_roi: # Mouse released
@@ -465,19 +466,19 @@ class VideoDisplayUI:
                             roi_end_screen = self._video_to_screen_coords(urx_vid + urw_vid, ury_vid + urh_vid)
 
                             if roi_start_screen and roi_end_screen:
-                                draw_list.add_rect(roi_start_screen[0],roi_start_screen[1],roi_end_screen[0],roi_end_screen[1],imgui.get_color_u32_rgba(0.1,0.9,0.9,0.8),thickness=2)
+                                draw_list.add_rect(roi_start_screen[0],roi_start_screen[1],roi_end_screen[0],roi_end_screen[1],imgui.get_color_u32_rgba(*VideoDisplayColors.ROI_BORDER),thickness=2)
                             if self.app.tracker.user_roi_tracked_point_relative: # UPDATED TO USE TRACKED POINT
                                 abs_tracked_x_vid = self.app.tracker.user_roi_fixed[0] + int(self.app.tracker.user_roi_tracked_point_relative[0])
                                 abs_tracked_y_vid = self.app.tracker.user_roi_fixed[1] + int(self.app.tracker.user_roi_tracked_point_relative[1])
                                 point_screen_coords = self._video_to_screen_coords(abs_tracked_x_vid,abs_tracked_y_vid)
                                 if point_screen_coords:
-                                    draw_list.add_circle_filled(point_screen_coords[0], point_screen_coords[1], 5, imgui.get_color_u32_rgba(0.2, 1, 0.2, 0.9)) # Green moving dot
+                                    draw_list.add_circle_filled(point_screen_coords[0], point_screen_coords[1], 5, imgui.get_color_u32_rgba(*VideoDisplayColors.TRACKING_POINT)) # Green moving dot
                                     if self.app.tracker.show_flow:
                                         dx_flow_vid, dy_flow_vid = self.app.tracker.user_roi_current_flow_vector
                                         flow_end_vid_x, flow_end_vid_y = abs_tracked_x_vid + int(dx_flow_vid * 10), abs_tracked_y_vid+int(dy_flow_vid*10)
                                         flow_end_screen_coords = self._video_to_screen_coords(flow_end_vid_x,flow_end_vid_y)
                                         if flow_end_screen_coords:
-                                            draw_list.add_line(point_screen_coords[0], point_screen_coords[1], flow_end_screen_coords[0], flow_end_screen_coords[1], imgui.get_color_u32_rgba(1, 0.2, 0.2, 0.9), thickness=2)
+                                            draw_list.add_line(point_screen_coords[0], point_screen_coords[1], flow_end_screen_coords[0], flow_end_screen_coords[1], imgui.get_color_u32_rgba(*VideoDisplayColors.FLOW_VECTOR), thickness=2)
                         self._handle_video_mouse_interaction(app_state)
 
                         if app_state.show_stage2_overlay and stage_proc.stage2_overlay_data_map and self.app.processor and \
@@ -682,13 +683,13 @@ class VideoDisplayUI:
 
                 # --- HIERARCHICAL HIGHLIGHTING LOGIC ---
                 if is_refined_track:
-                    color = (0.0, 1.0, 1.0, 1.0)  # Bright Cyan for the persistent refined track
+                    color = VideoDisplayColors.PERSISTENT_REFINED_TRACK  # Bright Cyan for the persistent refined track
                     thickness = 3.0
                 elif is_active_interactor:
-                    color = (1.0, 1.0, 0.0, 1.0)  # Bright Yellow for the ACTIVE interactor
+                    color = VideoDisplayColors.ACTIVE_INTERACTOR  # Bright Yellow for the ACTIVE interactor
                     thickness = 3.0
                 elif is_locked_penis:
-                    color = (0.1, 1.0, 0.1, 0.95)  # Bright Green for LOCKED PENIS
+                    color = VideoDisplayColors.LOCKED_PENIS  # Bright Green for LOCKED PENIS
                     thickness = 2.0
                     # If it's a locked penis and has a visible part, draw the solid fill first.
                     if "visible_bbox" in box and box["visible_bbox"]:
@@ -697,14 +698,14 @@ class VideoDisplayUI:
                         p2_vis = self._video_to_screen_coords(vis_bbox[2], vis_bbox[3])
                         if p1_vis and p2_vis:
                             # Use a semi-transparent fill of the same base color
-                            fill_color = (0.1, 1.0, 0.1, 0.4)
+                            fill_color = VideoDisplayColors.FILL_COLOR
                             fill_color_u32 = imgui.get_color_u32_rgba(*fill_color)
                             draw_list.add_rect_filled(p1_vis[0], p1_vis[1], p2_vis[0], p2_vis[1], fill_color_u32, rounding=2.0)
                 elif is_aligned_candidate:
-                    color = (1.0, 0.5, 0.0, 0.9)  # Orange for ALIGNED FALLBACK candidates
+                    color = VideoDisplayColors.ALIGNED_FALLBACK  # Orange for ALIGNED FALLBACK candidates
                     thickness = 1.5
                 elif is_inferred_status:
-                    color = (0.8, 0.4, 1.0, 0.85) # A distinct purple for inferred boxes
+                    color = VideoDisplayColors.INFERRED_BOX # A distinct purple for inferred boxes
                     thickness = 1.0
                 else:
                     color, thickness, _ = self.app.utility.get_box_style(box)
@@ -725,10 +726,10 @@ class VideoDisplayUI:
                 if is_of_recovered:
                     label += " [OF]"
 
-                draw_list.add_text(p1[0] + 3, p1[1] + 3, imgui.get_color_u32_rgba(1, 1, 1, 1), label)
+                draw_list.add_text(p1[0] + 3, p1[1] + 3, imgui.get_color_u32_rgba(*VideoDisplayColors.BOX_LABEL), label)
 
         if is_occluded:
-            draw_list.add_text(img_rect['min_x'] + 10, img_rect['max_y'] - 30, imgui.get_color_u32_rgba(1, 0.6, 0, 0.95), "OCCLUSION (FALLBACK)")
+            draw_list.add_text(img_rect['min_x'] + 10, img_rect['max_y'] - 30, imgui.get_color_u32_rgba(*VideoDisplayColors.OCCLUSION_WARNING), "OCCLUSION (FALLBACK)")
 
         motion_mode = frame_overlay_data.get("motion_mode")
         is_vr_video = self.app.processor and self.app.processor.determined_video_type == 'VR'

--- a/application/gui_components/video_navigation_ui.py
+++ b/application/gui_components/video_navigation_ui.py
@@ -5,6 +5,8 @@ from typing import Optional
 from application.utils.time_format import _format_time
 from config.constants import POSITION_INFO_MAPPING, DEFAULT_CHAPTER_FPS
 from application.utils.video_segment import VideoSegment
+from config.element_group_colors import VideoNavigationColors
+from config.constants_colors import CurrentTheme
 
 
 class VideoNavigationUI:
@@ -224,7 +226,7 @@ class VideoNavigationUI:
         bar_start_y = cursor_screen_pos[1]
         # bar_width is nav_content_width
 
-        bg_col = imgui.get_color_u32_rgba(0.1, 0.1, 0.12, 1.0)
+        bg_col = imgui.get_color_u32_rgba(*VideoNavigationColors.BACKGROUND)
         # Draw the background for the chapter bar using full bar_width
         draw_list.add_rect_filled(bar_start_x, bar_start_y, bar_start_x + bar_width, bar_start_y + bar_height, bg_col)
 
@@ -251,7 +253,7 @@ class VideoNavigationUI:
             if segment.user_roi_fixed:
                 icon_pos_x = seg_start_x + 3
                 icon_pos_y = bar_start_y + (bar_height - imgui.get_text_line_height()) / 2
-                icon_color = imgui.get_color_u32_rgba(1.0, 1.0, 0.2, 0.9)  # Bright Yellow
+                icon_color = imgui.get_color_u32_rgba(*VideoNavigationColors.ICON)  # Bright Yellow
                 # Using a simple character as an icon. A texture could be used for a nicer look.
                 draw_list.add_text(icon_pos_x, icon_pos_y, icon_color, "[R]")
 
@@ -259,7 +261,7 @@ class VideoNavigationUI:
             if not (isinstance(segment_color_tuple, (tuple, list)) and len(segment_color_tuple) in [3, 4]):
                 self.app.logger.warning(
                     f"Segment {segment.unique_id} ('{segment.class_name if hasattr(segment, 'class_name') else 'N/A'}') has invalid color {segment_color_tuple}, using default gray.")
-                segment_color_tuple = (0.5, 0.5, 0.5, 0.7)
+                segment_color_tuple = (*CurrentTheme.GRAY_MEDIUM[:3], 0.7)  # Using GRAY_MEDIUM with 0.7 alpha
             seg_color = imgui.get_color_u32_rgba(*segment_color_tuple)
 
             is_selected_for_scripting = (fs_proc.scripting_range_active
@@ -280,15 +282,15 @@ class VideoNavigationUI:
                 is_context_selected_secondary = True
 
             if is_selected_for_scripting:
-                scripting_border_col = imgui.get_color_u32_rgba(1.0, 1.0, 0.0, 0.6)
+                scripting_border_col = imgui.get_color_u32_rgba(*VideoNavigationColors.SCRIPTING_BORDER)
                 draw_list.add_rect(seg_start_x + 0.5, bar_start_y + 0.5, seg_start_x + seg_width - 0.5, bar_start_y + bar_height - 0.5, scripting_border_col, thickness=1.0, rounding=0.0)
 
             if is_context_selected_primary:
-                border_col_sel1 = imgui.get_color_u32_rgba(0.2, 1.0, 0.2, 0.95)
+                border_col_sel1 = imgui.get_color_u32_rgba(*VideoNavigationColors.SELECTION_PRIMARY)
                 draw_list.add_rect(seg_start_x - 1, bar_start_y - 1, seg_start_x + seg_width + 1, bar_start_y + bar_height + 1, border_col_sel1, thickness=2.0, rounding=1.0)
 
             if is_context_selected_secondary:
-                border_col_sel2 = imgui.get_color_u32_rgba(0.3, 0.5, 1.0, 0.95)
+                border_col_sel2 = imgui.get_color_u32_rgba(*VideoNavigationColors.SELECTION_SECONDARY)
                 draw_list.add_rect(seg_start_x - 2, bar_start_y - 2, seg_start_x + seg_width + 2, bar_start_y + bar_height + 2, border_col_sel2, thickness=1.5, rounding=1.0)
 
             text_to_draw = f"{segment.position_short_name}"
@@ -297,9 +299,9 @@ class VideoNavigationUI:
                 text_pos_x = seg_start_x + (seg_width - text_width) / 2
                 text_pos_y = bar_start_y + (bar_height - imgui.get_text_line_height()) / 2
                 valid_color_for_lum = segment_color_tuple if isinstance(segment_color_tuple, tuple) and len(
-                    segment_color_tuple) >= 3 else (0.5, 0.5, 0.5)
+                    segment_color_tuple) >= 3 else CurrentTheme.GRAY_MEDIUM[:3]  # Using GRAY_MEDIUM
                 lum = 0.2100 * valid_color_for_lum[0] + 0.587 * valid_color_for_lum[1] + 0.114 * valid_color_for_lum[2]
-                text_color = imgui.get_color_u32_rgba(0, 0, 0, 1) if lum > 0.6 else imgui.get_color_u32_rgba(1, 1, 1, 1)
+                text_color = imgui.get_color_u32_rgba(*VideoNavigationColors.TEXT_BLACK) if lum > 0.6 else imgui.get_color_u32_rgba(*VideoNavigationColors.TEXT_WHITE)
                 draw_list.add_text(text_pos_x, text_pos_y, text_color, text_to_draw)
 
             imgui.set_cursor_screen_pos((seg_start_x, bar_start_y))
@@ -354,7 +356,7 @@ class VideoNavigationUI:
             current_norm_pos = self.app.processor.current_frame_index / total_video_frames
             # marker_x = bar_start_x + current_norm_pos * bar_width
             marker_x = effective_marker_area_start_x + current_norm_pos * effective_marker_area_width
-            marker_col = imgui.get_color_u32_rgba(1.0, 1.0, 1.0, 0.7)
+            marker_col = imgui.get_color_u32_rgba(*VideoNavigationColors.MARKER)
             draw_list.add_line(marker_x, bar_start_y, marker_x, bar_start_y + bar_height, marker_col, thickness=2.0)
 
         io = imgui.get_io()
@@ -1023,7 +1025,7 @@ class ChapterListWindow:
                     cursor_pos = imgui.get_cursor_screen_pos()
                     swatch_start = (cursor_pos[0] + 2, cursor_pos[1] + 2)
                     swatch_end = (cursor_pos[0] + imgui.get_column_width() - 2, swatch_start[1] + 16)
-                    color_tuple = chapter.color if isinstance(chapter.color, (tuple, list)) else (0.5, 0.5, 0.5, 0.7)
+                    color_tuple = chapter.color if isinstance(chapter.color, (tuple, list)) else (*CurrentTheme.GRAY_MEDIUM[:3], 0.7)  # Using GRAY_MEDIUM with 0.7 alpha
                     color_u32 = imgui.get_color_u32_rgba(*color_tuple)
                     draw_list.add_rect_filled(swatch_start[0], swatch_start[1], swatch_end[0], swatch_end[1], color_u32, rounding=3.0)
 

--- a/config/constants.py
+++ b/config/constants.py
@@ -1,5 +1,7 @@
 import platform
 import os
+import enum
+from typing import Dict, List, Tuple, Any
 from enum import Enum, auto
 
 # Attempt to import torch for device detection, but fail gracefully if it's not available.
@@ -120,30 +122,8 @@ MAX_HISTORY_DISPLAY = 10  # Max number of actions to show in the Undo/Redo histo
 UI_PREVIEW_UPDATE_INTERVAL_S = 1.0  # Interval for updating graphs during live tracking.
 DEFAULT_CHAPTER_BAR_HEIGHT = 20  # Height in pixels of the chapter bar.
 
-# --- Timeline & Heatmap Colors ---
-TIMELINE_HEATMAP_COLORS = [
-    (30, 144, 255),   # Dodger Blue
-    (34, 139, 34),    # Lime Green
-    (255, 215, 0),    # Gold
-    (220, 20, 60),    # Crimson
-    (147, 112, 219),  # Medium Purple
-    (37, 22, 122)     # Dark Blue (Cap color)
-]
-TIMELINE_COLOR_SPEED_STEP = 250.0  # Speed (pixels/sec) used to step through the color map.
-TIMELINE_COLOR_ALPHA = 0.9
-
-# --- Default Chapter Colors (used in video_segment.py) ---
-DEFAULT_CHAPTER_COLORS = {
-    "BJ": (0.9, 0.4, 0.4, 0.8),
-    "HJ": (0.4, 0.9, 0.4, 0.8),
-    "NR": (0.6, 0.6, 0.6, 0.7),
-    "CG/Miss.": (0.4, 0.4, 0.9, 0.8),
-    "R.CG/Dog.": (0.9, 0.6, 0.2, 0.8),
-    "FootJ": (0.9, 0.9, 0.3, 0.8),
-    "BoobJ": (0.9, 0.3, 0.6, 0.8),
-    "C-Up": (0.7, 0.7, 0.9, 0.8),
-    "default": (0.5, 0.5, 0.5, 0.7)
-}
+# --- Timeline & Heatmap Colors (now imported from constants_colors.py) ---
+# Timeline colors are now managed through constants_colors.py
 
 
 ####################################################################################################
@@ -154,12 +134,6 @@ CLASS_NAMES_TO_IDS = {
     'anus': 6, 'breast': 7, 'navel': 8, 'foot': 9, 'hips center': 10
 }
 CLASS_IDS_TO_NAMES = {v: k for k, v in CLASS_NAMES_TO_IDS.items()}
-CLASS_COLORS = {
-    "penis": (255, 0, 0), "glans": (0, 128, 0), "pussy": (0, 0, 255), "butt": (0, 180, 255),
-    "anus": (128, 0, 128), "breast": (255, 165, 0), "navel": (0, 255, 255),
-    "hand": (255, 0, 255), "face": (0, 255, 0), "foot": (165, 42, 42),
-    "hips center": (0, 0, 0), "locked_penis": (0, 255, 255),
-}
 CLASSES_TO_DISCARD_BY_DEFAULT = ["anus"]
 
 INTERACTION_ZONES = {
@@ -358,8 +332,6 @@ STATUS_GENERATED_RTS = "Generated_RTS"
 SHORT_GAP_THRESHOLD = 2
 LONG_GAP_THRESHOLD = 30
 RTS_WINDOW_PADDING = 20 # Frames to include before start_frame and after end_frame for RTS window
-
-
 
 # --- Constants from new helper scripts ---
 # From smooth_tracked_classes.py

--- a/config/constants_colors.py
+++ b/config/constants_colors.py
@@ -1,0 +1,214 @@
+"""
+Color constants for GUI components with theme support.
+Centralizes all color definitions to replace hardcoded RGBA values throughout the codebase.
+All constants are named by their actual color, not their purpose.
+Naming scheme: COLOR_SHADE (e.g., BLUE_LIGHT, GRAY_DARK)
+"""
+
+# TODO: Structure colors. Global base colors (full opaque), class themes with modified base colors.
+
+# Dark Theme Colors (RGBA format: red, green, blue, alpha) - values from 0.0 to 1.0
+class DarkTheme:
+    # Basic Colors
+    RED = (0.9, 0.2, 0.2, 1.0)
+    RED_LIGHT = (0.9, 0.4, 0.4, 0.8)
+    RED_DARK = (0.7, 0.2, 0.2, 1.0)
+
+    GREEN = (0.2, 0.8, 0.2, 1.0)
+    GREEN_LIGHT = (0.4, 0.9, 0.4, 0.8)
+    GREEN_DARK = (0.2, 0.7, 0.2, 1.0)
+
+    BLUE = (0.2, 0.2, 0.9, 1.0)
+    BLUE_LIGHT = (0.7, 0.9, 1.0, 1.0)
+    BLUE_DARK = (0.2, 0.35, 0.6, 0.6)
+
+    YELLOW = (0.9, 0.9, 0.2, 1.0)
+    YELLOW_LIGHT = (0.9, 0.9, 0.3, 0.8)
+    YELLOW_DARK = (0.8, 0.8, 0.2, 1.0)
+
+    CYAN = (0.1, 0.9, 0.9, 1.0)
+    MAGENTA = (0.9, 0.2, 0.9, 1.0)
+
+    WHITE = (1.0, 1.0, 1.0, 1.0)
+    WHITE_DARK = (0.9, 0.9, 0.9, 1.0)
+    BLACK = (0.0, 0.0, 0.0, 1.0)
+    GRAY = (0.7, 0.7, 0.7, 1.0)
+    GRAY_LIGHT = (0.8, 0.8, 0.8, 1.0)
+    GRAY_DARK = (0.3, 0.3, 0.3, 1.0)
+    GRAY_MEDIUM = (0.5, 0.5, 0.5, 1.0)
+
+    ORANGE = (1.0, 0.6, 0.0, 1.0)
+    ORANGE_LIGHT = (1.0, 0.8, 0.4, 0.8)
+    ORANGE_DARK = (0.9, 0.6, 0.0, 1.0)
+    
+    BROWN = (0.9, 0.6, 0.2, 0.8)
+    PURPLE = (0.7, 0.7, 0.9, 0.8)
+    PINK = (0.9, 0.3, 0.6, 0.8)
+
+    TRANSPARENT = (0, 0, 0, 0)
+    SEMI_TRANSPARENT = (0, 0, 0, 0.4)
+
+    
+    # App GUI Colors
+    APP_MARKER = (*RED[:3], 0.85)  # Red marker for app GUI
+    FLOATING_WIDGET_BG = (0.1, 0.1, 0.1, 1.0) # dark gray
+    FLOATING_WIDGET_BORDER = GRAY_MEDIUM
+    FLOATING_WIDGET_TEXT = WHITE_DARK
+
+    # Gauge-specific colors
+    GAUGE_BG = FLOATING_WIDGET_BG
+    GAUGE_BORDER = FLOATING_WIDGET_BORDER
+    GAUGE_BAR_RED = RED_DARK
+    GAUGE_BAR_GREEN = GREEN_DARK
+    GAUGE_TEXT = FLOATING_WIDGET_TEXT
+    GAUGE_VALUE_TEXT = YELLOW
+
+    # LR Dial Colors
+    LR_DIAL_BACKGROUND = FLOATING_WIDGET_BG
+    LR_DIAL_BORDER = FLOATING_WIDGET_BORDER
+    LR_DIAL_LEFT_LABEL = RED
+    LR_DIAL_RIGHT_LABEL = BLUE
+    LR_DIAL_INDICATOR_LINE = CYAN
+    LR_DIAL_INDICATOR_TIP = YELLOW
+    LR_DIAL_VALUE_TEXT = YELLOW
+
+    # Timeline Colors
+    TIMELINE_CANVAS_BG = (0.08, 0.08, 0.1, 1.0) # dark gray
+    TIMELINE_MARKER = (*RED[:3], 0.9)
+    TIMELINE_TIME_TEXT = (*WHITE[:3], 0.7)
+    TIMELINE_GRID = (*GRAY_DARK[:3], 0.8)
+    TIMELINE_GRID_MAJOR = (*GRAY_DARK[:3], 0.9)
+    TIMELINE_GRID_LABELS = GRAY
+    TIMELINE_WAVEFORM = BLUE_DARK
+    TIMELINE_SELECTED_BORDER = (0.6, 0.0, 0.0, 1.0) # dark red
+    TIMELINE_PREVIEW_LINE = (*ORANGE[:3], 0.9)
+    TIMELINE_PREVIEW_POINT = ORANGE
+    TIMELINE_MARQUEE_FILL = (0.5, 0.5, 1.0, 0.3) # light blue
+    TIMELINE_MARQUEE_BORDER = (0.8, 0.8, 1.0, 0.7) # light blue
+    TIMELINE_POINT_DEFAULT = GREEN
+    TIMELINE_POINT_DRAGGING = RED
+    TIMELINE_POINT_SELECTED = (1.0, 0.0, 0.0, 1.0) # dark red
+    TIMELINE_POINT_HOVER = (0.5, 1.0, 0.5, 1.0) # light green
+
+    # Compiler Colors
+    COMPILER_SUCCESS = GREEN
+    COMPILER_ERROR = RED
+    COMPILER_INFO = GRAY
+    COMPILER_WARNING = YELLOW
+    COMPILER_STARTING = ORANGE
+    COMPILER_STOPPING = YELLOW
+    COMPILER_OUTPUT_TEXT = BLUE_LIGHT
+
+    # Video Display Colors
+    VIDEO_DOMINANT_LIMB = (*GREEN[:3], 0.95)
+    VIDEO_DOMINANT_KEYPOINT = (1.0, 0.5, 0.1, 1.0) # orange
+    VIDEO_MUTED_LIMB = (0.2, 0.6, 1.0, 0.4) # muted cyan
+    VIDEO_MUTED_KEYPOINT = (*RED[:3], 0.5)
+    VIDEO_MOTION_UNDETERMINED = (*YELLOW[:3], 0.9)
+    VIDEO_MOTION_THRUSTING = (*GREEN[:3], 0.95)
+    VIDEO_MOTION_RIDING = (*MAGENTA[:3], 0.95)
+    VIDEO_ROI_DRAWING = (*YELLOW[:3], 0.7)
+    VIDEO_ROI_BORDER = (*CYAN[:3], 0.7)
+    VIDEO_TRACKING_POINT = (*GREEN[:3], 0.9)
+    VIDEO_FLOW_VECTOR = (*RED[:3], 0.9)
+    VIDEO_BOX_LABEL = WHITE
+    VIDEO_OCCLUSION_WARNING = (*ORANGE[:3], 0.95)
+    VIDEO_PERSISTENT_REFINED_TRACK = CYAN
+    VIDEO_ACTIVE_INTERACTOR = YELLOW
+    VIDEO_LOCKED_PENIS = GREEN_DARK
+    VIDEO_FILL_COLOR = (*GREEN[:3], 0.4)
+    VIDEO_ALIGNED_FALLBACK = (*ORANGE[:3], 0.9)
+    VIDEO_INFERRED_BOX = (*PURPLE[:3], 0.85)
+
+    # Navigation Colors
+    NAV_BACKGROUND = (0.1, 0.1, 0.12, 1.0) # dark gray
+    NAV_ICON = (*YELLOW[:3], 0.9)
+    NAV_SCRIPTING_BORDER = (*YELLOW[:3], 0.6)
+    NAV_SELECTION_PRIMARY = (*GREEN[:3], 0.95)
+    NAV_SELECTION_SECONDARY = (0.3, 0.5, 1.0, 0.95) # blue
+    NAV_TEXT_BLACK = BLACK
+    NAV_TEXT_WHITE = WHITE
+    NAV_MARKER = (*WHITE[:3], 0.7)
+
+    # Box Style Colors
+    BOX_GENERAL = (*GRAY_LIGHT[:3], 0.7)
+    BOX_PREF_PENIS = (*GREEN[:3], 0.9)
+    BOX_LOCKED_PENIS = (*CYAN[:3], 0.8)
+    BOX_PUSSY = (1.0, 0.5, 0.8, 0.8) # pink
+    BOX_BUTT = (*BROWN[:3], 0.8)
+    BOX_TRACKED = (*YELLOW[:3], 0.8)
+    BOX_TRACKED_ALT = (*GRAY[:3], 0.7)
+    BOX_GENERAL_DETECTION = (0.2, 0.5, 1.0, 0.6) # blue
+    BOX_EXCLUDED = (0.5, 0.1, 0.1, 0.5) # dark red
+
+    # Segment Colors
+    SEGMENT_BJ = (*GREEN_LIGHT[:3], 0.8)
+    SEGMENT_HJ = (*GREEN_LIGHT[:3], 0.8)
+    SEGMENT_NR = (*GRAY[:3], 0.7)
+    SEGMENT_CG_MISS = (0.4, 0.4, 0.9, 0.8) # blue
+    SEGMENT_REV_CG_DOG = (*BROWN[:3], 0.8)
+    SEGMENT_FOOTJ = (*YELLOW_LIGHT[:3], 0.8)
+    SEGMENT_BOOBJ = (*PINK[:3], 0.8)
+    SEGMENT_CLOSEUP = (*PURPLE[:3], 0.8)
+    SEGMENT_DEFAULT = TRANSPARENT
+
+    # Control Panel Colors
+    CONTROL_PANEL_ACTIVE_PROGRESS = (0.2, 0.6, 1.0, 1.0) # blue
+    CONTROL_PANEL_COMPLETED_PROGRESS = (0.2, 0.7, 0.2, 1.0) # green
+    CONTROL_PANEL_SUB_PROGRESS = (0.3, 0.7, 1.0, 1.0) # cyan
+
+# Current theme (default to dark)
+CurrentTheme = DarkTheme
+
+class RGBColors:
+    # RGB Colors (for legacy compatibility - 0-255 range)
+    WHITE = (255, 255, 255)
+    BLACK = (0, 0, 0)
+    GREY = (128, 128, 128)
+    GREY_LIGHT = (180, 180, 180)
+    GREY_DARK = (64, 64, 64)
+    RED = (255, 0, 0)
+    GREEN = (0, 255, 0)
+    GREEN_DARK = (0, 128, 0)
+    BLUE = (0, 0, 255)
+    BLUE_DARK = (0, 0, 128)
+    YELLOW = (255, 255, 0)
+    TEAL = (0, 220, 220)
+    CYAN = (0, 255, 255)
+    ORANGE = (255, 165, 0)
+    ORANGE_LIGHT = (255, 180, 0)
+    MAGENTA = (255, 0, 255)
+    PURPLE = (128, 0, 128)
+
+
+    TIMELINE_HEATMAP = [
+        (30, 144, 255),   # Dodger Blue
+        (34, 139, 34),    # Lime Green
+        (255, 215, 0),    # Gold
+        (220, 20, 60),    # Crimson
+        (147, 112, 219),  # Medium Purple
+        (37, 22, 122)     # Dark Blue (Cap color)
+    ]
+    TIMELINE_COLOR_SPEED_STEP = 250.0  # Speed (pixels/sec) used to step through the color map.
+    TIMELINE_COLOR_ALPHA = 0.9 # alpha value for the timeline heatmap
+
+    # General Slider Colors
+    FPS_TARGET_MARKER = YELLOW
+    FPS_TRACKER_MARKER = GREEN
+    FPS_PROCESSOR_MARKER = RED
+
+    # OBJECT DETECTION CLASS COLORS
+    CLASS_COLORS = {
+        "penis": RED,
+        "glans": GREEN_DARK,
+        "pussy": BLUE,
+        "butt": ORANGE_LIGHT,
+        "anus": PURPLE,
+        "breast": ORANGE,
+        "navel": CYAN,
+        "hand": MAGENTA,
+        "face": GREEN,
+        "foot": (165, 42, 42), # Brown
+        "hips center": BLACK,
+        "locked_penis": CYAN,
+    }

--- a/config/element_group_colors.py
+++ b/config/element_group_colors.py
@@ -1,0 +1,167 @@
+"""
+Color element groups for organizing UI colors by component.
+This provides a structured way to manage colors for different UI elements.
+"""
+
+from config.constants_colors import CurrentTheme, RGBColors
+
+
+class GaugeColors:
+    """Color constants for gauge components."""
+    BACKGROUND = CurrentTheme.GAUGE_BG
+    BORDER = CurrentTheme.GAUGE_BORDER
+    BAR_RED = CurrentTheme.GAUGE_BAR_RED
+    BAR_GREEN = CurrentTheme.GAUGE_BAR_GREEN
+    TEXT = CurrentTheme.GAUGE_TEXT
+    VALUE_TEXT = CurrentTheme.GAUGE_VALUE_TEXT
+
+
+class TimelineColors:
+    """Color constants for interactive timeline components."""
+    CANVAS_BACKGROUND = CurrentTheme.TIMELINE_CANVAS_BG
+    CENTER_MARKER = CurrentTheme.TIMELINE_MARKER
+    TIME_DISPLAY_TEXT = CurrentTheme.TIMELINE_TIME_TEXT
+    GRID_LINES = CurrentTheme.TIMELINE_GRID
+    GRID_MAJOR_LINES = CurrentTheme.TIMELINE_GRID_MAJOR
+    GRID_LABELS = CurrentTheme.TIMELINE_GRID_LABELS
+    AUDIO_WAVEFORM = CurrentTheme.TIMELINE_WAVEFORM
+    SELECTED_POINT_BORDER = CurrentTheme.TIMELINE_SELECTED_BORDER
+    PREVIEW_LINES = CurrentTheme.TIMELINE_PREVIEW_LINE
+    PREVIEW_POINTS = CurrentTheme.TIMELINE_PREVIEW_POINT
+    MARQUEE_SELECTION_FILL = CurrentTheme.TIMELINE_MARQUEE_FILL
+    MARQUEE_SELECTION_BORDER = CurrentTheme.TIMELINE_MARQUEE_BORDER
+    POINT_DEFAULT = CurrentTheme.TIMELINE_POINT_DEFAULT
+    POINT_DRAGGING = CurrentTheme.TIMELINE_POINT_DRAGGING
+    POINT_SELECTED = CurrentTheme.TIMELINE_POINT_SELECTED
+    POINT_HOVER = CurrentTheme.TIMELINE_POINT_HOVER
+
+
+class CompilerToolColors:
+    """Color constants for TensorRT compiler components."""
+    SUCCESS = CurrentTheme.COMPILER_SUCCESS
+    ERROR = CurrentTheme.COMPILER_ERROR
+    INFO = CurrentTheme.COMPILER_INFO
+    WARNING = CurrentTheme.COMPILER_WARNING
+    STARTING = CurrentTheme.COMPILER_STARTING
+    STOPPING = CurrentTheme.COMPILER_STOPPING
+    OUTPUT_TEXT = CurrentTheme.COMPILER_OUTPUT_TEXT
+
+
+class LRDialColors:
+    """Color constants for LR dial components."""
+    BACKGROUND = CurrentTheme.LR_DIAL_BACKGROUND
+    BORDER = CurrentTheme.LR_DIAL_BORDER
+    LEFT_LABEL = CurrentTheme.LR_DIAL_LEFT_LABEL
+    RIGHT_LABEL = CurrentTheme.LR_DIAL_RIGHT_LABEL
+    INDICATOR_LINE = CurrentTheme.LR_DIAL_INDICATOR_LINE
+    INDICATOR_TIP = CurrentTheme.LR_DIAL_INDICATOR_TIP
+    VALUE_TEXT = CurrentTheme.LR_DIAL_VALUE_TEXT
+
+
+class VideoDisplayColors:
+    """Color constants for video display components."""
+    # Pose skeleton colors
+    DOMINANT_LIMB = CurrentTheme.VIDEO_DOMINANT_LIMB
+    DOMINANT_KEYPOINT = CurrentTheme.VIDEO_DOMINANT_KEYPOINT
+    MUTED_LIMB = CurrentTheme.VIDEO_MUTED_LIMB
+    MUTED_KEYPOINT = CurrentTheme.VIDEO_MUTED_KEYPOINT
+    
+    # Motion mode colors
+    MOTION_UNDETERMINED = CurrentTheme.VIDEO_MOTION_UNDETERMINED
+    MOTION_THRUSTING = CurrentTheme.VIDEO_MOTION_THRUSTING
+    MOTION_RIDING = CurrentTheme.VIDEO_MOTION_RIDING
+    
+    # ROI and tracking colors
+    ROI_DRAWING = CurrentTheme.VIDEO_ROI_DRAWING
+    ROI_BORDER = CurrentTheme.VIDEO_ROI_BORDER
+    TRACKING_POINT = CurrentTheme.VIDEO_TRACKING_POINT
+    FLOW_VECTOR = CurrentTheme.VIDEO_FLOW_VECTOR
+    
+    # Overlay colors
+    BOX_LABEL = CurrentTheme.VIDEO_BOX_LABEL
+    OCCLUSION_WARNING = CurrentTheme.VIDEO_OCCLUSION_WARNING
+    
+    # Additional video display colors
+    PERSISTENT_REFINED_TRACK = CurrentTheme.VIDEO_PERSISTENT_REFINED_TRACK
+    ACTIVE_INTERACTOR = CurrentTheme.VIDEO_ACTIVE_INTERACTOR
+    LOCKED_PENIS = CurrentTheme.VIDEO_LOCKED_PENIS
+    FILL_COLOR = CurrentTheme.VIDEO_FILL_COLOR
+    ALIGNED_FALLBACK = CurrentTheme.VIDEO_ALIGNED_FALLBACK
+    INFERRED_BOX = CurrentTheme.VIDEO_INFERRED_BOX
+
+
+class ControlPanelColors:
+    """Color constants for control panel components."""
+    ACTIVE_PROGRESS = CurrentTheme.CONTROL_PANEL_ACTIVE_PROGRESS
+    COMPLETED_PROGRESS = CurrentTheme.CONTROL_PANEL_COMPLETED_PROGRESS
+    SUB_PROGRESS = CurrentTheme.CONTROL_PANEL_SUB_PROGRESS
+
+
+class VideoNavigationColors:
+    """Color constants for video navigation components."""
+    BACKGROUND = CurrentTheme.NAV_BACKGROUND
+    ICON = CurrentTheme.NAV_ICON
+    SCRIPTING_BORDER = CurrentTheme.NAV_SCRIPTING_BORDER
+    SELECTION_PRIMARY = CurrentTheme.NAV_SELECTION_PRIMARY
+    SELECTION_SECONDARY = CurrentTheme.NAV_SELECTION_SECONDARY
+    TEXT_BLACK = CurrentTheme.NAV_TEXT_BLACK
+    TEXT_WHITE = CurrentTheme.NAV_TEXT_WHITE
+    MARKER = CurrentTheme.NAV_MARKER
+
+
+class AppGUIColors:
+    """Color constants for app GUI components."""
+    MARKER = CurrentTheme.APP_MARKER
+
+    """Color constants for general UI sliders."""
+    FPS_TARGET_MARKER = RGBColors.FPS_TARGET_MARKER
+    FPS_TRACKER_MARKER = RGBColors.FPS_TRACKER_MARKER
+    FPS_PROCESSOR_MARKER = RGBColors.FPS_PROCESSOR_MARKER
+
+    TRANSPARENT = CurrentTheme.TRANSPARENT
+    SEMI_TRANSPARENT = CurrentTheme.SEMI_TRANSPARENT
+
+
+class SegmentColors:
+    """Color constants for video segment components."""
+    BJ = CurrentTheme.SEGMENT_BJ
+    HJ = CurrentTheme.SEGMENT_HJ
+    NR = CurrentTheme.SEGMENT_NR
+    CG_MISS = CurrentTheme.SEGMENT_CG_MISS
+    REV_CG_DOG = CurrentTheme.SEGMENT_REV_CG_DOG
+    FOOTJ = CurrentTheme.SEGMENT_FOOTJ
+    BOOBJ = CurrentTheme.SEGMENT_BOOBJ
+    CLOSEUP = CurrentTheme.SEGMENT_CLOSEUP
+    DEFAULT = CurrentTheme.SEGMENT_DEFAULT
+
+
+class BoxStyleColors:
+    """Color constants for box style components."""
+    GENERAL = CurrentTheme.BOX_GENERAL
+    PREF_PENIS = CurrentTheme.BOX_PREF_PENIS
+    LOCKED_PENIS = CurrentTheme.BOX_LOCKED_PENIS
+    PUSSY = CurrentTheme.BOX_PUSSY
+    BUTT = CurrentTheme.BOX_BUTT
+    TRACKED = CurrentTheme.BOX_TRACKED
+    TRACKED_ALT = CurrentTheme.BOX_TRACKED_ALT
+    GENERAL_DETECTION = CurrentTheme.BOX_GENERAL_DETECTION
+    EXCLUDED = CurrentTheme.BOX_EXCLUDED
+
+
+class GeneralColors:
+    """General color constants for common UI elements."""
+    WHITE = CurrentTheme.WHITE
+    BLACK = CurrentTheme.BLACK
+    GRAY = CurrentTheme.GRAY
+    GRAY_LIGHT = CurrentTheme.GRAY_LIGHT
+    GRAY_DARK = CurrentTheme.GRAY_DARK
+    RED = CurrentTheme.RED
+    GREEN = CurrentTheme.GREEN
+    BLUE = CurrentTheme.BLUE
+    YELLOW = CurrentTheme.YELLOW
+    CYAN = CurrentTheme.CYAN
+    MAGENTA = CurrentTheme.MAGENTA
+    ORANGE = CurrentTheme.ORANGE
+    PURPLE = CurrentTheme.PURPLE
+    PINK = CurrentTheme.PINK
+    BROWN = CurrentTheme.BROWN 

--- a/config/theme_manager.py
+++ b/config/theme_manager.py
@@ -1,0 +1,106 @@
+"""
+Theme manager for handling color themes.
+Provides easy theme switching and management.
+"""
+
+from config.constants_colors import DarkTheme, CurrentTheme
+
+
+class ThemeManager:
+    """Manages color themes for the application."""
+    
+    def __init__(self):
+        self._current_theme = DarkTheme
+        self._available_themes = {
+            'dark': DarkTheme,
+        }
+    
+    @property
+    def current_theme(self):
+        """Get the current theme."""
+        return self._current_theme
+    
+    @property
+    def available_themes(self):
+        """Get list of available theme names."""
+        return list(self._available_themes.keys())
+    
+    def set_theme(self, theme_name: str) -> bool:
+        """
+        Set the current theme by name.
+        
+        Args:
+            theme_name: Name of the theme to set
+            
+        Returns:
+            True if theme was set successfully, False otherwise
+        """
+        if theme_name not in self._available_themes:
+            return False
+        
+        self._current_theme = self._available_themes[theme_name]
+        
+        # Update the global CurrentTheme reference
+        import config.constants_colors
+        config.constants_colors.CurrentTheme = self._current_theme
+        
+        # Update all color element groups
+        self._update_color_groups()
+        
+        return True
+    
+    def get_theme(self, theme_name: str):
+        """
+        Get a theme by name.
+        
+        Args:
+            theme_name: Name of the theme to get
+            
+        Returns:
+            Theme class or None if not found
+        """
+        return self._available_themes.get(theme_name)
+    
+    def add_theme(self, theme_name: str, theme_class):
+        """
+        Add a new theme.
+        
+        Args:
+            theme_name: Name for the new theme
+            theme_class: Theme class to add
+        """
+        self._available_themes[theme_name] = theme_class
+    
+    def _update_color_groups(self):
+        """Update all color element groups to use the new theme."""
+        # This would be called when switching themes
+        # For now, the color groups automatically use CurrentTheme
+        # so they'll update automatically
+        pass
+
+
+# Global theme manager instance
+theme_manager = ThemeManager()
+
+
+def set_theme(theme_name: str) -> bool:
+    """
+    Convenience function to set the current theme.
+    
+    Args:
+        theme_name: Name of the theme to set
+        
+    Returns:
+        True if theme was set successfully, False otherwise
+    """
+    return theme_manager.set_theme(theme_name)
+
+
+def get_current_theme():
+    """Get the current theme."""
+    return theme_manager.current_theme
+
+
+def get_available_themes():
+    """Get list of available theme names."""
+    return theme_manager.available_themes 


### PR DESCRIPTION
- Colors can now be set in constants_colors.py
_(colors are set here)_

- Colors are loaded via element_group_colors.py
_(colors are loaded here. You import from here.)_

- Theme support ready.
_(theme_manager.py; Not used yet!)_

- Reformat heatmap coloring logic, in preperation of lowering compute cycles.

---

I kept all the original colors though it could be streamlined more by reusing colors.
For example these don't have any noticable difference
- (0.2, 0.8, 0.2, 1.0)
- (0.2, 0.8, 0.2, 0.95)
- (*GREEN[:3], 0.95)

---

color management logic:
- constants_colors.py **->** element_group_colors.py **->** from config.element_group_colors import ...