### PR TITLE
fix(timeline): guard heatmap segment speeds

### DIFF
--- a/application/utils/heatmap_utils.py
+++ b/application/utils/heatmap_utils.py
@@ -104,11 +104,23 @@ class HeatmapColorMapper:
             return np.array([], dtype=np.float32)
 
         if ats_np is not None and poss_np is not None:
-            ats = ats_np.astype(np.float64)
-            poss = poss_np.astype(np.float64)
+            # Guard against cached numpy arrays being out of sync length-wise
+            min_len = min(ats_np.shape[0], poss_np.shape[0])
+            if min_len == 0:
+                return np.array([], dtype=np.float32)
+            ats = ats_np[:min_len].astype(np.float64)
+            poss = poss_np[:min_len].astype(np.float64)
         else:
             ats = np.array([a['at'] for a in actions], dtype=np.float64)
             poss = np.array([a['pos'] for a in actions], dtype=np.float64)
+
+        if len(ats) != len(poss):
+            min_len = min(len(ats), len(poss))
+            ats = ats[:min_len]
+            poss = poss[:min_len]
+
+        if len(ats) < 2:
+            return np.array([], dtype=np.float32)
 
         dt = np.diff(ats)  # ms
         dp = np.abs(np.diff(poss))  # position units


### PR DESCRIPTION
Guard compute_segment_speeds against mismatched cached numpy arrays by truncating to the shared length and returning empty when fewer than two points remain, preventing shape-broadcast errors during heatmap rendering.

The original error message

> 10:20:05 INFO  [app_logic:1255] Application logic shutdown complete.
Traceback (most recent call last):
  File "C:\Users\hwoarang\Downloads\FunGen\main.py", line 319, in <module>
    main()
  File "C:\Users\hwoarang\Downloads\FunGen\main.py", line 316, in main
    run_gui()
  File "C:\Users\hwoarang\Downloads\FunGen\main.py", line 114, in run_gui
    gui.run()
  File "C:\Users\hwoarang\Downloads\FunGen\application\gui_components\app_gui.py", line 1672, in run
    self.render_gui()
  File "C:\Users\hwoarang\Downloads\FunGen\application\gui_components\app_gui.py", line 1603, in render_gui
    self._render_fixed_layout(app_state, font_scale, toolbar_height, status_strip_h)
  File "C:\Users\hwoarang\Downloads\FunGen\application\gui_components\app_gui.py", line 1081, in _render_fixed_layout
    self._time_render("TimelineEditor1", self.timeline_editor1.render, timeline_current_y_start, timeline1_render_h, view_mode=app_state.ui_view_mode)
  File "C:\Users\hwoarang\Downloads\FunGen\application\gui_components\app_gui.py", line 223, in _time_render
    render_func(*args, **kwargs)
  File "C:\Users\hwoarang\Downloads\FunGen\application\classes\interactive_timeline.py", line 318, in render
    self._draw_curve_heatmap(draw_list, tf, main_actions)
  File "C:\Users\hwoarang\Downloads\FunGen\application\classes\interactive_timeline.py", line 1423, in _draw_curve_heatmap
    self._heatmap_speeds_cache = HeatmapColorMapper.compute_segment_speeds(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hwoarang\Downloads\FunGen\application\utils\heatmap_utils.py", line 118, in compute_segment_speeds
    speeds = (dp / dt_safe) * 1000.0  # units/sec
              ~~~^~~~~~~~~
ValueError: operands could not be broadcast together with shapes (1957,) (1956,)