### PR TITLE
Normalize chapter names and harden chapter import fallbacks

### DIFF
--- a/application/logic/app_stage_executor.py
+++ b/application/logic/app_stage_executor.py
@@ -332,6 +332,9 @@ class StageExecutorMixin:
                 fps = (self.app.processor.video_info.get('fps', 30.0)
                        if self.app.processor and self.app.processor.video_info else 30.0)
                 for chapter in funscript_obj.chapters:
+                    chapter_name = chapter.get('name') or chapter.get('position_long') or "Unknown"
+                    chapter_short = chapter.get('position_short') or chapter_name
+                    chapter_long = chapter.get('position_long') or chapter.get('description') or chapter_name
                     start_frame = int((chapter.get('start', 0) / 1000.0) * fps)
                     end_frame = int((chapter.get('end', 0) / 1000.0) * fps)
                     from application.utils.video_segment import VideoSegment as VS
@@ -339,10 +342,10 @@ class StageExecutorMixin:
                         start_frame_id=start_frame,
                         end_frame_id=end_frame,
                         class_id=chapter.get('class_id'),
-                        class_name=chapter.get('name', 'Unknown'),
+                        class_name=chapter_name,
                         segment_type="SexAct",
-                        position_short_name=chapter.get('position_short', chapter.get('name', '')),
-                        position_long_name=chapter.get('position_long', chapter.get('description', chapter.get('name', 'Unknown'))),
+                        position_short_name=chapter_short,
+                        position_long_name=chapter_long,
                         source="stage2_funscript"
                     )
                     fs_proc.video_chapters.append(video_segment)

--- a/application/logic/app_stage_gui_events.py
+++ b/application/logic/app_stage_gui_events.py
@@ -344,7 +344,7 @@ class StageGuiEventsMixin:
             for chapter in funscript_obj.chapters:
                 start_frame = int((chapter.get('start', 0) / 1000.0) * fps)
                 end_frame = int((chapter.get('end', 0) / 1000.0) * fps)
-                raw_name = chapter.get('name', 'Unknown')
+                raw_name = chapter.get('name') or chapter.get('position_long') or "Unknown"
                 short_name = self._get_position_short_name(raw_name)
                 video_segment = VideoSegment(
                     start_frame_id=start_frame,

--- a/funscript/multi_axis_funscript.py
+++ b/funscript/multi_axis_funscript.py
@@ -1619,8 +1619,9 @@ class MultiAxisFunscript:
             start_time_ms = int((start_frame_id / video_fps) * 1000)
             end_time_ms = int((end_frame_id / video_fps) * 1000)
             
+            chapter_name = position_long or position_short or "Unknown"
             chapter = {
-                "name": position_short,  # Use short name for UI display
+                "name": chapter_name,
                 "start": start_time_ms,
                 "end": end_time_ms,
                 "startTime": start_time_ms,  # Keep both for compatibility
@@ -1661,4 +1662,3 @@ class MultiAxisFunscript:
         }
         self.chapters.append(chapter)
         self.logger.debug(f"Added chapter '{name}' ({start_time_ms}-{end_time_ms}ms)")
-


### PR DESCRIPTION
This PR fixes chapter label inconsistencies when users run Chapter Maker first, then VR Hybrid, then export.

### Problem

Some generated funscripts ended up with short chapter names (NR, R.CG/Dog.), and in certain stage conversion paths ch
apter labels could appear as None in UI, even though tooltip data still looked correct.

### Root Cause

- set_chapters_from_segments() stored chapter name using short labels.
- Later stage-to-VideoSegment conversion paths assumed name/long fields and did not guard against missing or None
values.

### Changes

- funscript/multi_axis_funscript.py
- In set_chapters_from_segments(), chapter name is now normalized to long/preferred name (position_long first,
then short, then Unknown).
- application/logic/app_stage_executor.py
- Hardened chapter field extraction with fallback chain for name, position_short, and position_long.
- application/logic/app_stage_gui_events.py
- Same fallback hardening for chapter name extraction to avoid None labels.

### Impact

- Prevents None chapter names in the described workflow.
- Keeps chapter naming consistent across Chapter Maker, VR Hybrid, and export.
- Improves resilience when chapter dictionaries have partial/missing fields.