### PR TITLE
Improve Rev. Cowgirl chapter classification robustness

### DIFF
--- a/tracker/tracker_modules/helpers/chapter_detection.py
+++ b/tracker/tracker_modules/helpers/chapter_detection.py
@@ -123,6 +123,15 @@ def classify_frame_position(penis_box: Dict, other_boxes: List[Dict]) -> str:
                 contacts.append(other)
 
     if not contacts:
+        # Weak fallback: if genital contact classes are visible but IoU/proximity
+        # was too strict this frame, prefer a plausible position over "Close up".
+        genital_candidates = [b for b in other_boxes if b.get('class') in ('butt', 'anus')]
+        if genital_candidates:
+            best = max(genital_candidates, key=lambda b: (
+                CONTACT_PRIORITY.get(b.get('class'), 0),
+                (b['box'][2] - b['box'][0]) * (b['box'][3] - b['box'][1])
+            ))
+            return CONTACT_TO_POSITION.get(best.get('class'), 'Close up')
         return 'Close up'
 
     best_contact = max(contacts, key=lambda c: CONTACT_PRIORITY.get(c['class'], 0))

--- a/tracker/tracker_modules/offline/vr_hybrid_chapter_tracker.py
+++ b/tracker/tracker_modules/offline/vr_hybrid_chapter_tracker.py
@@ -423,7 +423,7 @@ class VRHybridChapterTrackerV2(BaseOfflineTracker):
                                 'penis': penis_box['box'],
                                 'contacts': [ob['box'] for ob in other_boxes],
                             }
-                        elif len(other_boxes) >= 2:
+                        elif len(other_boxes) >= 1:
                             position = classify_no_penis(other_boxes, self.yolo_input_size)
                         else:
                             position = 'Not Relevant'


### PR DESCRIPTION
This PR reduces false Not Relevant classifications for scenes that should be labeled Rev. Cowgirl / Doggy, especially
under partial detection conditions.

### Problem

Some high-motion Rev. Cowgirl segments were incorrectly classified as Not Relevant because classification was too
strict when penis/contact matching was incomplete on sparse chapter frames.

### Changes

- tracker/tracker_modules/helpers/chapter_detection.py
- In classify_frame_position(), added a weak fallback:
- If no contact passes IoU/proximity checks, but butt/anus detections exist, classify from the best genital
candidate instead of defaulting directly to Close up.
- tracker/tracker_modules/offline/vr_hybrid_chapter_tracker.py
- Relaxed no-penis gate from len(other_boxes) >= 2 to >= 1 before calling classify_no_penis().

### Impact

- Fewer Rev. Cowgirl / Doggy -> Not Relevant misclassifications.
- Better tolerance to temporary detector misses in sparse chapter sampling.
- Shared helper change also benefits Chapter Maker behavior.

### Screenshots

#### Before
<img width="384" height="118" alt="before1" src="https://github.com/user-attachments/assets/d3dd1b0d-c4b3-4799-9acc-d3f5acd4ac08" />

#### After
<img width="432" height="82" alt="after1" src="https://github.com/user-attachments/assets/dbdfc30c-d104-4248-bb16-1c51000b7378" />